### PR TITLE
20210607 nb inter admin

### DIFF
--- a/front-end/components/connectionForm.vue
+++ b/front-end/components/connectionForm.vue
@@ -7,6 +7,7 @@
             id="emailInput"
             type="email"
             v-model="mail"
+            v-on:keyup.enter="submit"
             required
             name="mail"
             v-validate="{required: true, email: true}"
@@ -24,6 +25,7 @@
             id="pwdInput"
             type="password"
             v-model="password"
+            v-on:keyup.enter="submit"
             required
             name="mail"
             v-validate="{required: true, min:8}"

--- a/front-end/pages/admin/index.vue
+++ b/front-end/pages/admin/index.vue
@@ -143,7 +143,9 @@
                   <h4 v-if="loading === false">
                     <i class="material-icons accordion-chevron">chevron_right</i>
                     <i class="material-icons ml-2 mr-2">poll</i>
-                    Accès aux indicateurs : {{statStructure['nationale'].nbAttestations}} attestations enregistrées depuis Avril 2019
+                    <!-- Correction anomalie : Le compteur ne donnait que la dernière année-->
+                    <!--Accès aux indicateurs : {{statStructure['nationale'].nbAttestations}} {{nbAttestations}} attestations enregistrées depuis Avril 2019-->
+                    Accès aux indicateurs : {{nbAttestations}} attestations enregistrées depuis Avril 2019
                   </h4>
                   <h4 v-else>
                     <i class="material-icons accordion-chevron">chevron_right</i>
@@ -557,7 +559,8 @@ export default {
         { text: "Actif", value: "Actif" },
         { text: "Bloqué", value: "Actif" },
         { text: "Tous", value: "Tous" }
-      ]
+      ],
+      nbAttestations: 0
     };
   },
 
@@ -1068,6 +1071,20 @@ export default {
       }),
       this.$store.dispatch("get_interventions"),
     ]);
+    // Calcul du nombre d'interventions
+    const url = process.env.API_URL + "/interventions/nbattestations?str_id=0";
+    console.info(url);
+    this.$axios.$get(url)
+    .then(response => {
+      if (response) 
+      {
+        console.log("nbAttestations",response.nbattestations )
+        this.nbAttestations= response.nbattestations;
+      }
+    }).catch(err => {
+      console.log(err)
+    })
+
 
     // Calcul des stats définies dans le mixins stat.js
     this.statCal(this.interventions, this.structures)

--- a/front-end/pages/partenaire/index.vue
+++ b/front-end/pages/partenaire/index.vue
@@ -114,7 +114,10 @@
                     >
                     <i class="material-icons ml-2 mr-2">poll</i>
                     Accès aux indicateurs :
+                    <!--
                     {{ statStructure[structure2].nbAttestations }} attestations
+                    -->
+                    {{nbAttestations}} attestations
                     enregistrées depuis Avril 2019
                   </h4>
                   <h4 v-else>
@@ -500,6 +503,7 @@ export default {
           sortable: true,
         },
       ],
+      nbAttestations: 0,
     };
   },
 
@@ -1076,6 +1080,21 @@ export default {
 
       }
     });
+
+    // Calcul du nombre d'interventions
+    const url = process.env.API_URL + "/interventions/nbattestations?str_id=" + String(this.$store.state.utilisateurCourant.structureId);
+    console.info(url);
+    this.$axios.$get(url)
+    .then(response => {
+      if (response) 
+      {
+        console.log("nbAttestations",response.nbattestations )
+        this.nbAttestations= response.nbattestations;
+      }
+    }).catch(err => {
+      console.log(err)
+    })
+
     this.remplissage = this.statStructure[this.structure1].CouleurParDepartement,
 
     // Affichage des graphiques


### PR DESCRIPTION
- Correction du compteur du nombre d'attestations sur l'accordéon Indicateur de l'espace Admin et Partenaire
=> Le compteur affichait l'année en cours (Nb d'attestations depuis J-1 an) qui correspond à l'affichage des graphiques
- Ajout du bouton "Entrée" par défaut sur l'écran de connexion sur les champs login et mot de passe.