### PR TITLE
20211207 blocage interventions

### DIFF
--- a/back-end/routes/export.js
+++ b/back-end/routes/export.js
@@ -161,11 +161,13 @@ router.get('/intervention/', async function (req, res) {
 */
 
     // ATTENTION : Ne pas toucher sans se référer au paramétrage de la cartographie opendatasoft DataSource "Savoir rouler à vélo intervention"
+    // Ajout de la clause sur la date d'intervention, on n'envoie pas les interventions qui n'ont pas encore eu lieu.
     requete =`SELECT to_char(int.int_dateintervention,'DD/MM/YYYY') int_dateintervention,int.int_nombreenfant , int.int_dep_num, int.int_com_libelle, int.int_com_codeinsee, int.int_com_codepostal, int.int_reg_num from intervention int
     INNER JOIN bloc blo ON blo.blo_id = int.blo_id and blo.blo_id = 3
     INNER JOIN cadreintervention cai ON cai.cai_id = int.cai_id 
     INNER JOIN utilisateur uti ON int.uti_id = uti.uti_id 
     INNER JOIN structure str ON str.str_id = uti.str_id
+    WHERE to_char(int.int_dateintervention,'YYYMMDD') < to_char(current_date,'YYYMMDD')
     order by int.int_id asc`;
 
     pgPool.query(requete, (err, result) => {

--- a/back-end/routes/parametres.js
+++ b/back-end/routes/parametres.js
@@ -10,12 +10,12 @@ var moment = require('moment');
 
 // Route permettant de récupérer la valeur d'un paramètre dans la table paramètres
 // exemple : http://localhost/backend/api/parametres?code=PROTO_APPLI
-router.get('/', (req, res) => {
+router.get('/:codeParametre',async (req, res) => {
     log.i('::parametres - In')
 
     //var startTime = new Date();
     var requete = "";
-    var parametre = req.query.code
+    const  parametre = req.params.codeParametre
 
     log.d('::parametres - du paramètre : ' + parametre);
 
@@ -38,7 +38,8 @@ router.get('/', (req, res) => {
             }
             else
             {
-                return res.send(resultat[0]);
+                res.json({ parametre: resultat[0] });
+               // return res.send(resultat[0]);
             }
         }
     })

--- a/back-end/utils/mail-service.js
+++ b/back-end/utils/mail-service.js
@@ -77,7 +77,7 @@ module.exports = {
             body: `
             <p>Bonjour,</p>
 
-            <p>Vous recevez ce mail car vous avez effecuté une demande de réinitialisation de mot de passe sur le site Savoir Rouler à vélo</p>
+            <p>Vous recevez ce mail car vous avez effectué une demande de réinitialisation de mot de passe sur le site Savoir Rouler à vélo</p>
 
             <p>Veuillez entamer la procédure en cliquant sur le lien suivant:</p>
 
@@ -133,11 +133,22 @@ module.exports = {
         */
         console.log('EMail to  : ' + mailUtilisateurCourant)
 
-        sendEmail({
+
+
+        const params = {
             to: mailUtilisateurCourant,
             subject: objetMail,
-            body: corpsMail
+            body: corpsMail,
+            from: SENDER_EMAIL,
+            replyTo: SENDER_EMAIL
+            }
+        axios.post(sendNotificationUrl,  params).then(() => {
+            log.i('sendStatusNotification - Done', {params})
         })
+        .catch(err => {
+            log.w('sendStatusNotification', err)
+        })
+        //sendEmail(params)
         return 1
     }
 }

--- a/back-end/utils/utils.js
+++ b/back-end/utils/utils.js
@@ -6,7 +6,8 @@
 
 var config = require('../config')
 var moment = require('moment');
-
+moment().format();
+const fs = require('fs');
 
 module.exports = {
 
@@ -125,6 +126,14 @@ module.exports = {
     return result
   },
   logTrace : (batch,codeerreur,startTime) => {
+    const now = new Date();
+    var jour = now.getDate().toString().padStart(2, "0");
+    var mois = now.getMonth().toString().padStart(2, "0");
+    var annee = now.getFullYear();
+    var heure = now.getHours().toString().padStart(2, "0");
+    var minute = now.getMinutes().toString().padStart(2, "0");
+    var dateTimeFormate = annee + mois + jour + heure + minute;
+
     var execTime = new Date() - startTime;
     var fichierSupervision = config.PATH_SUPERVISION_BATCH;
     var checkLog;
@@ -135,7 +144,10 @@ module.exports = {
     {
         checkLog = 'Check log Backend SRAV';
     }    
-    var contenu = formatDate() + '|' + codeerreur + '|' + checkLog + '|ExecTime=' + execTime;
+    // L'appel à formatDate() ne fonctionne plus. A voir pourquoi. Duplication de code en attendant
+    //var contenu = formatDate() + '|' + codeerreur + '|' + checkLog + '|ExecTime=' + execTime;
+    var contenu = dateTimeFormate + '|' + codeerreur + '|' + checkLog + '|ExecTime=' + execTime;
+
 
     fs.writeFile(fichierSupervision + '/batch.' + batch + '.txt', contenu, function (err) {
         if (err) throw err;

--- a/front-end/components/Intervention.vue
+++ b/front-end/components/Intervention.vue
@@ -167,6 +167,12 @@
             Après mon intervention, je complète ou modifie les champs "nombre d'enfants", "genre" et "classe d'âge"
           </p>
         </div>
+        <div class="bv-example-row">
+          <p class="text-danger">
+            Une fois votre intervention déclarée, si besoin, vous avez jusqu'à <b>5 jours après la date de l'intervention pour la modifier</b>.<br>
+            Pour les interventions déclarées à postériori, vous avez <b>5 jours maximum après la date effective de l'intervention</b> pour effectuer la saisie.
+          </p>
+        </div>        
         <div
           class="mb-3 mt-3"
           v-if="formIntervention.dateMaj"
@@ -184,7 +190,7 @@
           </ul>
         </div>
 
-        <p class="modal-btns">
+        <p>
           <b-button
             v-on:click="resetform(); $modal.hide('editIntervention')"
             v-if="intervention.id"
@@ -256,6 +262,9 @@ export default {
   },
   data() {
     return {
+      parametreNbMoisMaxAnticip: null,
+      parametreNbJoursMaxRetroSaisie: null,
+      parametreNbJoursMaxModifInter: null,
       erreurformulaire: [],
       listecommune: [
         {
@@ -287,6 +296,12 @@ export default {
     };
   },
   methods: {
+    dateDiff: function(date1, date2){
+  date1 = date1.getTime() / 86400000;
+  date2 = date2.getTime() / 86400000;
+  return new Number(date2 - date1).toFixed(0);
+  
+  },
     showPDF: function(id) {
       console.info("showPDF");
       this.$axios({
@@ -343,6 +358,51 @@ export default {
         this.erreurformulaire.push("La date d'intervention");
         formOK = false;
       }
+      else
+      {
+
+        var date1 = this.formIntervention.dateIntervention;
+        var dateDelaiMaxAnticip = new Date()
+        dateDelaiMaxAnticip.setMonth(dateDelaiMaxAnticip.getMonth() + this.parametreNbMoisMaxAnticip);
+        var sdateDelaiMaxAnticip = dateDelaiMaxAnticip.toISOString().slice(0, 10)
+        var idateDelaiMaxAnticip = Number(sdateDelaiMaxAnticip.toString().replaceAll("-",""))
+        var idate1 = Number(date1.toString().replaceAll("-",""))
+        // Si la idateDelaiMaxAnticip (aujourd'hui + X mois) - date d'intervention > 0 Alors on a dépassé les X mois d'anticipation
+        /*
+        console.log("Delai:", this.parametreNbMoisMaxAnticip)
+        console.log("idateDelaiMaxAnticip:", idateDelaiMaxAnticip)
+        console.log("idate1:", idate1)
+        console.log("Delta:", idateDelaiMaxAnticip-idate1)
+        */
+        if (idateDelaiMaxAnticip-idate1<0) 
+        {
+          formOK = false;
+          this.erreurformulaire.push("La date d'intervention ne peut être anticipée de plus de " + this.parametreNbMoisMaxAnticip + " mois");
+        }
+
+
+        var dateRetroSaisie = new Date()
+        dateRetroSaisie.setDate(dateRetroSaisie.getDate() - this.parametreNbJoursMaxRetroSaisie);
+        var sdateRetroSaisie = dateRetroSaisie.toISOString().slice(0, 10)
+        var idateRetroSaisie = Number(sdateRetroSaisie.toString().replaceAll("-",""))
+        // Si la dateRetroSaisie (aujourd'hui - X jours) - date d'intervention <= 0 Alors on a dépassé les 5 jours pour la rétro saisie
+        /*
+        console.log("Delai:", this.parametreNbJoursMaxRetroSaisie)
+        console.log("idateRetroSaisie:", idateRetroSaisie)
+        console.log("idate1:", idate1)
+        console.log("Delta:", idate1-idateRetroSaisie)
+        */
+        if (idate1-idateRetroSaisie<=0) 
+        {
+          formOK = false;
+          this.erreurformulaire.push("La date d'intervention ne peut être antérieure de plus de " + this.parametreNbJoursMaxRetroSaisie + " jours");
+        }
+
+        
+      }
+
+      
+
       if (!this.formIntervention.cai) {
         this.erreurformulaire.push("Le cadre d'intervention");
         formOK = false;
@@ -474,6 +534,48 @@ export default {
     }
   },
   mounted() {
+
+    this.$store.dispatch("get_parametre", "MAX_ANTICIP_INTER")
+      .then(() => {
+        console.log(this.$store.state.parametreSelectionne.par_valeur)
+        this.parametreNbMoisMaxAnticip = Number(this.$store.state.parametreSelectionne.par_valeur)
+      })
+      .catch(error => {
+        console.error(
+          "Une erreur est survenue lors de la récupération du paramètre MAX_ANTICIP_INTER",
+          error
+        );
+      });    
+
+      this.$store.dispatch("get_parametre", "MAX_RETRO_INTER")
+        .then(() => {
+          console.log(this.$store.state.parametreSelectionne.par_valeur)
+          this.parametreNbJoursMaxRetroSaisie = Number(this.$store.state.parametreSelectionne.par_valeur)
+        })
+        .catch(error => {
+          console.error(
+            "Une erreur est survenue lors de la récupération du paramètre MAX_RETRO_INTER",
+            error
+          );
+        });    
+
+        
+      this.$store.dispatch("get_parametre", "MAX_MODIF_INTER")
+        .then(() => {
+          console.log(this.$store.state.parametreSelectionne.par_valeur)
+          this.parametreNbJoursMaxModifInter = Number(this.$store.state.parametreSelectionne.par_valeur)
+        })
+        .catch(error => {
+          console.error(
+            "Une erreur est survenue lors de la récupération du paramètre MAX_RETRO_INTER",
+            error
+          );
+        });    
+
+        
+
+
+
     this.recherchecommune().then(res => {
       if (this.formIntervention && this.formIntervention.commune) {
         this.selectedCommune = this.formIntervention.commune.cpi_codeinsee;

--- a/front-end/components/Intervention.vue
+++ b/front-end/components/Intervention.vue
@@ -19,6 +19,7 @@
         <div class="input-group-display">
           <span>Type de bloc * :</span>
           <b-form-select 
+            :disabled="this.isVerrouille"
             class="liste-deroulante"
             v-model="formIntervention.blocId" 
             :options="listebloc"/>
@@ -30,6 +31,7 @@
             <li class="input-group-display">
               <span>Code Postal * :</span>
               <b-form-input
+                :disabled="this.isVerrouille"
                 class="text-cinq-car"
                 aria-describedby="inputFormatterHelp"
                 maxlength="5"
@@ -41,6 +43,7 @@
             <li class="input-group-display">
               <span>Commune * :</span>
                 <b-form-select 
+                  :disabled="this.isVerrouille"
                   class="liste-deroulante"
                   v-model="selectedCommune">
                   <option :value="null">-- Choix de la commune --</option>
@@ -56,6 +59,7 @@
         <div class="input-group-display">
           <span>Nombre d'enfants * :</span>
             <b-form-input 
+              :disabled="this.isVerrouille"
               v-model="formIntervention.nbEnfants" 
               type="number" 
               min="0"
@@ -66,6 +70,7 @@
             <li>
               Dont
               <b-form-input 
+                :disabled="this.isVerrouille"
                 v-model="formIntervention.nbGarcons" 
                 type="number" 
                 min="0"
@@ -73,10 +78,12 @@
                 ></b-form-input>
               garçons et
               <b-form-input 
+                :disabled="this.isVerrouille"
                 v-model="formIntervention.nbFilles" 
                 type="number" 
                 min="0"
-                class="text-cinq-car"></b-form-input>
+                class="text-cinq-car"
+                ></b-form-input>
               filles
             </li>
             <li>
@@ -84,25 +91,25 @@
               <ul>
                 <li>
                   <span class="text-cinq-car">
-                    <b-form-input v-model="formIntervention.nbmoinssix" type="number" min="0"></b-form-input>
+                    <b-form-input :disabled="this.isVerrouille" v-model="formIntervention.nbmoinssix" type="number" min="0"></b-form-input>
                   </span>
                   moins de 6 ans
                 </li>
                 <li>
                   <span class="text-cinq-car">
-                    <b-form-input v-model="formIntervention.nbsixhuit" type="number" min="0"></b-form-input>
+                    <b-form-input :disabled="this.isVerrouille" v-model="formIntervention.nbsixhuit" type="number" min="0"></b-form-input>
                   </span>
                   6-7-8 ans
                 </li>
                 <li>
                   <span class="text-cinq-car">
-                    <b-form-input v-model="formIntervention.nbneufdix" type="number" min="0"></b-form-input>
+                    <b-form-input :disabled="this.isVerrouille" v-model="formIntervention.nbneufdix" type="number" min="0"></b-form-input>
                   </span>
                   9-10 ans
                 </li>
                 <li>
                   <span class="text-cinq-car">
-                    <b-form-input v-model="formIntervention.nbplusdix" type="number" min="0"></b-form-input>
+                    <b-form-input :disabled="this.isVerrouille" v-model="formIntervention.nbplusdix" type="number" min="0"></b-form-input>
                   </span>
                   plus de 10 ans
                 </li>
@@ -118,6 +125,7 @@
           <span>Date d'intervention * :</span>
           <b-form-input 
             maxlength="10" 
+            :disabled="this.isVerrouille"
             v-model="formIntervention.dateIntervention" 
             type="date"
             class="text-date date-input-width"></b-form-input>
@@ -132,6 +140,7 @@
           </b-popover>
           <b-form-group class="ml-3">
             <b-form-radio-group
+              :disabled="this.isVerrouille"
               v-model="formIntervention.cai"
               :options="listecadreintervention"
               plain
@@ -143,6 +152,7 @@
         <div class="input-group-display">
             <span>Site d'intervention :</span>
             <b-form-input 
+              :disabled="this.isVerrouille"
               v-model="formIntervention.siteintervention" 
               type="text"
               class="text"></b-form-input>
@@ -151,6 +161,7 @@
         <div class="mb-3 mt-3">
           <span>Commentaires libres :</span>
           <b-form-textarea
+            :disabled="this.isVerrouille"
             id="textarea1" 
             v-model="formIntervention.commentaire"
             placeholder
@@ -201,7 +212,7 @@
             v-if="!intervention.id"
             title="Réinitialiser le formulaire"
           >Réinitialiser le formulaire</b-button>
-          <b-button variant="success" v-on:click="checkform">Enregistrer</b-button>
+          <b-button :disabled="this.isVerrouille" variant="success" v-on:click="checkform">Enregistrer</b-button>
         </p>
       </b-col>
     </b-row>
@@ -210,6 +221,7 @@
 <script>
 import Vue from "vue";
 import moment from "moment";
+import { mapState } from "vuex";
 
 var loadFormIntervention = function(intervention) {
   let formIntervention = JSON.parse(
@@ -252,6 +264,7 @@ export default {
     }
   },
   computed: {
+    ...mapState(["utilisateurCourant"]),
     showAttestation() {
       return (
         this.intervention &&
@@ -262,6 +275,7 @@ export default {
   },
   data() {
     return {
+      isVerrouille: true,
       parametreNbMoisMaxAnticip: null,
       parametreNbJoursMaxRetroSaisie: null,
       parametreNbJoursMaxModifInter: null,
@@ -296,12 +310,6 @@ export default {
     };
   },
   methods: {
-    dateDiff: function(date1, date2){
-  date1 = date1.getTime() / 86400000;
-  date2 = date2.getTime() / 86400000;
-  return new Number(date2 - date1).toFixed(0);
-  
-  },
     showPDF: function(id) {
       console.info("showPDF");
       this.$axios({
@@ -374,12 +382,14 @@ export default {
         console.log("idate1:", idate1)
         console.log("Delta:", idateDelaiMaxAnticip-idate1)
         */
-        if (idateDelaiMaxAnticip-idate1<0) 
+        if (this.utilisateurCourant.profilId != 1)
         {
-          formOK = false;
-          this.erreurformulaire.push("La date d'intervention ne peut être anticipée de plus de " + this.parametreNbMoisMaxAnticip + " mois");
+          if (idateDelaiMaxAnticip-idate1<0) 
+          {
+            formOK = false;
+            this.erreurformulaire.push("La date d'intervention ne peut être anticipée de plus de " + this.parametreNbMoisMaxAnticip + " mois");
+          }
         }
-
 
         var dateRetroSaisie = new Date()
         dateRetroSaisie.setDate(dateRetroSaisie.getDate() - this.parametreNbJoursMaxRetroSaisie);
@@ -392,12 +402,14 @@ export default {
         console.log("idate1:", idate1)
         console.log("Delta:", idate1-idateRetroSaisie)
         */
-        if (idate1-idateRetroSaisie<=0) 
+        if (this.utilisateurCourant.profilId != 1)
         {
-          formOK = false;
-          this.erreurformulaire.push("La date d'intervention ne peut être antérieure de plus de " + this.parametreNbJoursMaxRetroSaisie + " jours");
+          if (idate1-idateRetroSaisie<0) 
+          {
+            formOK = false;
+            this.erreurformulaire.push("La date d'intervention ne peut être antérieure de plus de " + this.parametreNbJoursMaxRetroSaisie + " jours");
+          }
         }
-
         
       }
 
@@ -523,6 +535,15 @@ export default {
         formIntervention.dateIntervention
       );
       Vue.set(this, "formIntervention", loadFormIntervention(intervention));
+      
+/*
+var date1 = this.formIntervention.dateIntervention;
+      var dateDelaiMaxAnticip = new Date()
+      dateDelaiMaxAnticip.setMonth(dateDelaiMaxAnticip.getMonth() + this.parametreNbMoisMaxAnticip);
+      var sdateDelaiMaxAnticip = dateDelaiMaxAnticip.toISOString().slice(0, 10)
+      var idateDelaiMaxAnticip = Number(sdateDelaiMaxAnticip.toString().replaceAll("-",""))
+      var idate1 = Number(date1.toString().replaceAll("-",""))
+*/
     },
     "formIntervention.cp"(cp) {
       this.recherchecommune();
@@ -562,25 +583,53 @@ export default {
         
       this.$store.dispatch("get_parametre", "MAX_MODIF_INTER")
         .then(() => {
-          console.log(this.$store.state.parametreSelectionne.par_valeur)
           this.parametreNbJoursMaxModifInter = Number(this.$store.state.parametreSelectionne.par_valeur)
+
+          var date1 = new Date(this.formIntervention.dateIntervention);
+          date1.setDate(date1.getDate() + this.parametreNbJoursMaxModifInter);
+          var sdate1 = date1.toISOString().slice(0, 10)
+          var dateMaxModifInter = new Date()
+          var sdateMaxModifInter = dateMaxModifInter.toISOString().slice(0, 10)
+          var idateMaxModifInter = Number(sdateMaxModifInter.toString().replaceAll("-",""))
+          var idate1 = Number(sdate1.toString().replaceAll("-",""))
+          // Si la idateDelaiMaxAnticip (aujourd'hui + X mois) - date d'intervention > 0 Alors on a dépassé les X mois d'anticipation
+          /*          
+          console.log("Delai:", this.parametreNbJoursMaxModifInter)
+          console.log("idateMaxModifInter:", idateMaxModifInter)
+          console.log("idate1:", idate1)
+          console.log("Delta:", idateMaxModifInter-idate1)
+          */
+          if (this.utilisateurCourant.profilId != 1)
+          {
+            if (idateMaxModifInter-idate1>0) 
+            {
+              //console.log ("Intervention verrouillee")
+              this.isVerrouille = true;
+            }
+            else
+            {
+              //console.log ("Intervention NON verrouillee")
+              this.isVerrouille = false;
+            }
+          }
+          else
+          {
+            this.isVerrouille = false;
+          }
+
         })
         .catch(error => {
           console.error(
-            "Une erreur est survenue lors de la récupération du paramètre MAX_RETRO_INTER",
+            "Une erreur est survenue lors de la récupération du paramètre MAX_MODIF_INTER",
             error
           );
-        });    
+        }); 
 
-        
-
-
-
-    this.recherchecommune().then(res => {
-      if (this.formIntervention && this.formIntervention.commune) {
-        this.selectedCommune = this.formIntervention.commune.cpi_codeinsee;
-      }
-    });
+      this.recherchecommune().then(res => {
+        if (this.formIntervention && this.formIntervention.commune) {
+          this.selectedCommune = this.formIntervention.commune.cpi_codeinsee;
+        }
+      });
   }
 };
 </script>

--- a/front-end/store/index.js
+++ b/front-end/store/index.js
@@ -13,7 +13,8 @@ export const state = () => ({
   structures            : [],
   structureSelectionnee : [],
   documents             : [],
-  statStructure         : []
+  statStructure         : [],
+  parametreSelectionne : []
 
 });
 
@@ -129,6 +130,10 @@ export const mutations = {
     log.i(`mutations::set_documents`)    
     state.documents = documents
   },
+  set_parametreSelectionne(state, parametre) {
+    log.i(`mutations::set_parametreSelectionne`)
+    state.parametreSelectionne = parametre;
+  }
 };
 
 export const actions = {
@@ -405,7 +410,19 @@ export const actions = {
   set_state_element({ commit }, {key,value }) {
     log.i('actions::set_state_element - In',{key , value} )
     return commit('SET', { key, value })
-  }
+  },
+  async get_parametre({ commit,state }, codeParametre) {
+    log.i("actions::get_parametre - In");  
+    const url = process.env.API_URL + "/parametres/" + codeParametre;
+    return await this.$axios
+      .$get(url)
+      .then(response => {
+        commit("set_parametreSelectionne", response.parametre);
+      })
+      .catch(error => {
+        log.w("actions::get_parametre - In", error);
+      });
+  },
 };
 
 export const getters = {

--- a/pg/scripts/11-SQL_V1.1.4.sql
+++ b/pg/scripts/11-SQL_V1.1.4.sql
@@ -1,0 +1,3 @@
+INSERT INTO parametres (par_id, par_code, par_description, par_valeur) values (1,'MAX_ANTICIP_INTER','Délai maximum pour la déclaration anticipée des interventions (mois)','3');
+INSERT INTO parametres (par_id, par_code, par_description, par_valeur) values (2,'MAX_RETRO_INTER','Délai maximum pour la saisie à postériori des interventions (jours)','5');
+INSERT INTO parametres (par_id, par_code, par_description, par_valeur) values (3,'MAX_MODIF_INTER','Délai maximum pour modifier une intervention (jours)','5');


### PR DESCRIPTION
- Blocage des Interventions à J+5
- Blocage de la possibilité de rétrosaisir à J-5
- Blocage de la déclaration des interventions par anticipation à M + 3
- Mise à jour du batch de relance pour relancer jusqu'à 5 jours les demandes rétro saisies et les nouvelles demandes dans la limite des 5 jours après l'intervention
- Verrouillage de l'export des données vers ODS, limité à toutes les interventions passées (J-1 incluses)